### PR TITLE
[GS-56] 리뷰에 대한 답글

### DIFF
--- a/src/main/java/com/foo/gosucatcher/domain/bucket/domain/Bucket.java
+++ b/src/main/java/com/foo/gosucatcher/domain/bucket/domain/Bucket.java
@@ -44,11 +44,11 @@ public class Bucket extends BaseEntity {
 
 	@Builder
 	public Bucket(Expert expert, Member member) {
-		Long expertMemberId = expert.getMember().getId();
-		Long memberId = member.getId();
+		long expertMemberId = expert.getMember().getId();
+		long memberId = member.getId();
 
-		if (memberId.equals(expertMemberId)) {
-			throw new NotSupportedBucketException(ErrorCode.NOT_SUPPORTED_SELF_BUCKET);
+		if (memberId == expertMemberId) {
+			throw new NotSupportedBucketException(ErrorCode.UNSUPPORTED_SELF_BUCKET);
 		}
 
 		this.expert = expert;

--- a/src/main/java/com/foo/gosucatcher/domain/bucket/presentation/BucketController.java
+++ b/src/main/java/com/foo/gosucatcher/domain/bucket/presentation/BucketController.java
@@ -32,10 +32,10 @@ public class BucketController {
 	}
 
 	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> delete(@PathVariable Long id) {
+	public ResponseEntity<Object> delete(@PathVariable Long id) {
 		bucketService.deleteById(id);
 
-		return ResponseEntity.ok(null);
+		return ResponseEntity.noContent().build();
 	}
 
 	@PostMapping

--- a/src/main/java/com/foo/gosucatcher/domain/review/application/ReviewService.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/application/ReviewService.java
@@ -1,5 +1,7 @@
 package com.foo.gosucatcher.domain.review.application;
 
+import static com.foo.gosucatcher.global.error.ErrorCode.UNSUPPORTED_REPLIER;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -12,14 +14,19 @@ import com.foo.gosucatcher.domain.item.domain.SubItem;
 import com.foo.gosucatcher.domain.item.domain.SubItemRepository;
 import com.foo.gosucatcher.domain.member.domain.Member;
 import com.foo.gosucatcher.domain.member.domain.MemberRepository;
+import com.foo.gosucatcher.domain.review.application.dto.request.ReplyRequest;
 import com.foo.gosucatcher.domain.review.application.dto.request.ReviewCreateRequest;
 import com.foo.gosucatcher.domain.review.application.dto.request.ReviewUpdateRequest;
+import com.foo.gosucatcher.domain.review.application.dto.response.ReplyResponse;
 import com.foo.gosucatcher.domain.review.application.dto.response.ReviewResponse;
 import com.foo.gosucatcher.domain.review.application.dto.response.ReviewsResponse;
+import com.foo.gosucatcher.domain.review.domain.Reply;
+import com.foo.gosucatcher.domain.review.domain.ReplyRepository;
 import com.foo.gosucatcher.domain.review.domain.Review;
 import com.foo.gosucatcher.domain.review.domain.ReviewRepository;
 import com.foo.gosucatcher.global.error.ErrorCode;
 import com.foo.gosucatcher.global.error.exception.EntityNotFoundException;
+import com.foo.gosucatcher.global.error.exception.UnsupportedReplierException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,17 +36,18 @@ import lombok.RequiredArgsConstructor;
 public class ReviewService {
 
 	private final ReviewRepository reviewRepository;
+	private final ReplyRepository replyRepository;
 	private final ExpertRepository expertRepository;
 	private final MemberRepository memberRepository;
 	private final SubItemRepository subItemRepository;
 
 	public ReviewResponse create(Long expertId, Long subItemId, ReviewCreateRequest reviewCreateRequest) {
 		Expert expert = expertRepository.findById(expertId)
-				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_EXPERT));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_EXPERT));
 		Member writer = memberRepository.findById(reviewCreateRequest.writerId())
-				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
 		SubItem subItem = subItemRepository.findById(subItemId)
-				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_SUB_ITEM));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_SUB_ITEM));
 
 		Review review = ReviewCreateRequest.toReview(reviewCreateRequest, expert, writer, subItem);
 		reviewRepository.save(review);
@@ -55,23 +63,30 @@ public class ReviewService {
 	}
 
 	@Transactional(readOnly = true)
-	public ReviewsResponse findAllByExpertId(Pageable pageable, Long expertId) {
-		Slice<Review> reviews = reviewRepository.findAllByExpertId(expertId, pageable);
+	public ReviewsResponse findAllByExpertIdAndSubItem(Pageable pageable, Long expertId, Long subItemId) {
+		Slice<Review> reviews;
+
+		if (subItemId == null) {
+			reviews = reviewRepository.findAllByExpertId(expertId, pageable);
+		} else {
+			reviews = reviewRepository.findAllByExpertIdAndSubItemId(expertId, subItemId, pageable);
+		}
 
 		return ReviewsResponse.from(reviews);
+
 	}
 
 	@Transactional(readOnly = true)
 	public ReviewResponse findById(Long id) {
 		Review review = reviewRepository.findById(id)
-				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_REVIEW));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_REVIEW));
 
 		return ReviewResponse.from(review);
 	}
 
 	public Long update(Long id, ReviewUpdateRequest reviewUpdateRequest) {
 		Review review = reviewRepository.findById(id)
-				.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_REVIEW));
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_REVIEW));
 
 		Review updatedReview = ReviewUpdateRequest.toReview(reviewUpdateRequest);
 
@@ -82,10 +97,63 @@ public class ReviewService {
 
 	public void delete(Long id) {
 		reviewRepository.findById(id).ifPresentOrElse(
-				review -> reviewRepository.deleteById(id),
-				() -> {
-					throw new EntityNotFoundException(ErrorCode.NOT_FOUND_REVIEW);
-				}
+			review -> reviewRepository.deleteById(id),
+			() -> {
+				throw new EntityNotFoundException(ErrorCode.NOT_FOUND_REVIEW);
+			}
+		);
+	}
+
+	public ReplyResponse createReply(Long reviewId, ReplyRequest replyRequest) {
+		Review review = reviewRepository.findById(reviewId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_REVIEW));
+
+		validateReplyWriter(review, replyRequest);
+
+		Reply reply = ReplyRequest.toReply(replyRequest);
+		replyRepository.save(reply);
+		review.updateReply(reply);
+
+		return ReplyResponse.of(review.getId(), reply);
+	}
+
+	private void validateReplyWriter(Review review, ReplyRequest replyRequest) {
+		long expertId = review.getExpert().getId();
+		long writerId = replyRequest.writerId();
+
+		if (expertId != writerId) {
+			throw new UnsupportedReplierException(UNSUPPORTED_REPLIER);
+		}
+	}
+
+	public long updateReply(Long reviewId, long replyId, ReplyRequest replyRequest) {
+		Review review = reviewRepository.findById(reviewId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_REVIEW));
+
+		validateReplyWriter(review, replyRequest);
+
+		Reply reply = replyRepository.findById(replyId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_REPLY));
+
+		Reply updatedReply = ReplyRequest.toReply(replyRequest);
+		reply.update(updatedReply);
+
+		return replyId;
+	}
+
+	public ReplyResponse findReplyById(Long reviewId, Long replyId) {
+		Reply reply = replyRepository.findById(replyId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_REPLY));
+
+		return ReplyResponse.of(reviewId, reply);
+	}
+
+	public void deleteReply(Long reviewId, Long replyId) {
+		replyRepository.findById(replyId).ifPresentOrElse(
+			reply -> replyRepository.deleteById(replyId),
+			() -> {
+				throw new EntityNotFoundException(ErrorCode.NOT_FOUND_REPLY);
+			}
 		);
 	}
 

--- a/src/main/java/com/foo/gosucatcher/domain/review/application/dto/request/ReplyRequest.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/application/dto/request/ReplyRequest.java
@@ -1,0 +1,25 @@
+package com.foo.gosucatcher.domain.review.application.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.Length;
+
+import com.foo.gosucatcher.domain.review.domain.Reply;
+
+public record ReplyRequest(
+
+	@NotNull(message = "리뷰를 작성하는 고수의 ID를 입력해주세요")
+	Long writerId,
+
+	@NotBlank(message = "리뷰에 대한 답글을 입력해주세요")
+	@Length(min = 10, max = 600, message = "10자 이상 600자 이하로 입력 가능합니다")
+	String content
+) {
+
+	public static Reply toReply(ReplyRequest replyRequest) {
+		return Reply.builder()
+			.content(replyRequest.content())
+			.build();
+	}
+}

--- a/src/main/java/com/foo/gosucatcher/domain/review/application/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/application/dto/request/ReviewCreateRequest.java
@@ -13,26 +13,26 @@ import com.foo.gosucatcher.domain.member.domain.Member;
 import com.foo.gosucatcher.domain.review.domain.Review;
 
 public record ReviewCreateRequest(
-		@NotNull(message = "리뷰를 작성하는 사용자 ID를 입력해주세요")
-		Long writerId,
+	@NotNull(message = "리뷰를 작성하는 사용자 ID를 입력해주세요")
+	Long writerId,
 
-		@NotBlank(message = "리뷰를 입력해주세요")
-		@Length(min = 10, max = 600, message = "10자 이상 600자 이하로 입력 가능합니다")
-		String description,
+	@NotBlank(message = "리뷰를 입력해주세요")
+	@Length(min = 10, max = 600, message = "10자 이상 600자 이하로 입력 가능합니다")
+	String content,
 
-		@Min(value = 1, message = "별점은 1점 이상만 입력 가능합니다")
-		@Max(value = 5, message = "별점은 5점 이하만 입력 가능합니다")
-		int rating
+	@Min(value = 1, message = "별점은 1점 이상만 입력 가능합니다")
+	@Max(value = 5, message = "별점은 5점 이하만 입력 가능합니다")
+	int rating
 ) {
 
 	public static Review toReview(ReviewCreateRequest reviewCreateRequest, Expert expert, Member writer,
-			SubItem subItem) {
+		SubItem subItem) {
 		return Review.builder()
-				.expert(expert)
-				.member(writer)
-				.subItem(subItem)
-				.description(reviewCreateRequest.description())
-				.rating(reviewCreateRequest.rating())
-				.build();
+			.expert(expert)
+			.member(writer)
+			.subItem(subItem)
+			.content(reviewCreateRequest.content())
+			.rating(reviewCreateRequest.rating())
+			.build();
 	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/review/application/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/application/dto/request/ReviewUpdateRequest.java
@@ -13,30 +13,30 @@ import com.foo.gosucatcher.domain.review.domain.Review;
 
 public record ReviewUpdateRequest(
 
-		@NotBlank(message = "리뷰를 입력해주세요")
-		@Length(min = 10, max = 600, message = "10자 이상 600자 이하로 입력 가능합니다")
-		String description,
+	@NotBlank(message = "리뷰를 입력해주세요")
+	@Length(min = 10, max = 600, message = "10자 이상 600자 이하로 입력 가능합니다")
+	String content,
 
-		@Min(value = 1, message = "별점은 1점 이상만 입력 가능합니다")
-		@Max(value = 5, message = "별점은 5점 이하만 입력 가능합니다")
-		int rating
+	@Min(value = 1, message = "별점은 1점 이상만 입력 가능합니다")
+	@Max(value = 5, message = "별점은 5점 이하만 입력 가능합니다")
+	int rating
 ) {
 
 	public static Review toReview(ReviewUpdateRequest reviewUpdateRequest, Expert expert, Member writer,
-			SubItem subItem) {
+		SubItem subItem) {
 		return Review.builder()
-				.expert(expert)
-				.member(writer)
-				.subItem(subItem)
-				.description(reviewUpdateRequest.description())
-				.rating(reviewUpdateRequest.rating())
-				.build();
+			.expert(expert)
+			.member(writer)
+			.subItem(subItem)
+			.content(reviewUpdateRequest.content())
+			.rating(reviewUpdateRequest.rating())
+			.build();
 	}
 
 	public static Review toReview(ReviewUpdateRequest reviewUpdateRequest) {
 		return Review.builder()
-				.description(reviewUpdateRequest.description())
-				.rating(reviewUpdateRequest.rating())
-				.build();
+			.content(reviewUpdateRequest.content())
+			.rating(reviewUpdateRequest.rating())
+			.build();
 	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/review/application/dto/response/ReplyResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/application/dto/response/ReplyResponse.java
@@ -1,0 +1,19 @@
+package com.foo.gosucatcher.domain.review.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.foo.gosucatcher.domain.review.domain.Reply;
+
+public record ReplyResponse(
+	Long id,
+	Long reviewId,
+	String content,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+
+	public static ReplyResponse of(long reviewId, Reply reply) {
+		return new ReplyResponse(reply.getId(), reviewId, reply.getContent(), reply.getCreatedAt(),
+			reply.getUpdatedAt());
+	}
+}

--- a/src/main/java/com/foo/gosucatcher/domain/review/application/dto/response/ReviewResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/application/dto/response/ReviewResponse.java
@@ -1,23 +1,37 @@
 package com.foo.gosucatcher.domain.review.application.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.Dictionary;
+import java.util.Hashtable;
 
 import com.foo.gosucatcher.domain.review.domain.Review;
 
 public record ReviewResponse(
-		Long id,
-		Long expertId,
-		Long writerId,
-		Long subItemId,
-		String description,
-		int rating,
-		LocalDateTime createdAt,
-		LocalDateTime updatedAt
+	Long id,
+	Long expertId,
+	Long writerId,
+	Long subItemId,
+	String content,
+	int rating,
+	boolean replyExisted,
+	Dictionary<String, String> reply,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
 ) {
 
 	public static ReviewResponse from(Review review) {
+		Dictionary<String, String> reply = new Hashtable<>();
+		boolean replyExisted = review.getReply() != null;
+
+		if (replyExisted) {
+			reply.put("id", review.getReply().getId().toString());
+			reply.put("content", review.getReply().getContent());
+			reply.put("createdAt", review.getReply().getCreatedAt().toString());
+			reply.put("UpdatedAt", review.getReply().getUpdatedAt().toString());
+		}
+
 		return new ReviewResponse(review.getId(), review.getExpert().getId(), review.getMember().getId(),
-				review.getSubItem().getId(), review.getDescription(), review.getRating(), review.getCreatedAt(),
-				review.getUpdatedAt());
+			review.getSubItem().getId(), review.getContent(), review.getRating(), replyExisted,
+			reply, review.getCreatedAt(), review.getUpdatedAt());
 	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/review/application/dto/response/ReviewResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/application/dto/response/ReviewResponse.java
@@ -1,8 +1,8 @@
 package com.foo.gosucatcher.domain.review.application.dto.response;
 
 import java.time.LocalDateTime;
-import java.util.Dictionary;
-import java.util.Hashtable;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.foo.gosucatcher.domain.review.domain.Review;
 
@@ -14,13 +14,13 @@ public record ReviewResponse(
 	String content,
 	int rating,
 	boolean replyExisted,
-	Dictionary<String, String> reply,
+	Map<String, String> reply,
 	LocalDateTime createdAt,
 	LocalDateTime updatedAt
 ) {
 
 	public static ReviewResponse from(Review review) {
-		Dictionary<String, String> reply = new Hashtable<>();
+		Map<String, String> reply = new HashMap<>();
 		boolean replyExisted = review.getReply() != null;
 
 		if (replyExisted) {

--- a/src/main/java/com/foo/gosucatcher/domain/review/domain/Reply.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/domain/Reply.java
@@ -1,0 +1,43 @@
+package com.foo.gosucatcher.domain.review.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import com.foo.gosucatcher.global.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "replies")
+@Where(clause = "is_deleted = false")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE replies SET is_deleted = true WHERE id = ?")
+public class Reply extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String content;
+
+	private final boolean isDeleted = false;
+
+	@Builder
+	public Reply(String content) {
+		this.content = content;
+	}
+
+	public void update(Reply reply) {
+		content = reply.getContent();
+	}
+}

--- a/src/main/java/com/foo/gosucatcher/domain/review/domain/ReplyRepository.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/domain/ReplyRepository.java
@@ -1,0 +1,6 @@
+package com.foo.gosucatcher.domain.review.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+}

--- a/src/main/java/com/foo/gosucatcher/domain/review/domain/Review.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/domain/Review.java
@@ -1,5 +1,6 @@
 package com.foo.gosucatcher.domain.review.domain;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -46,24 +47,32 @@ public class Review extends BaseEntity {
 	@JoinColumn(name = "sub_item_id")
 	private SubItem subItem;
 
-	private String description;
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+	@JoinColumn(name = "reply_id")
+	private Reply reply;
+
+	private String content;
 
 	private int rating;
 
 	private boolean isDeleted = false;
 
 	@Builder
-	public Review(Expert expert, Member member, SubItem subItem, String description, int rating) {
+	public Review(Expert expert, Member member, SubItem subItem, String content, int rating) {
 		this.expert = expert;
 		this.member = member;
 		this.subItem = subItem;
-		this.description = description;
+		this.content = content;
 		this.rating = rating;
 		this.isDeleted = false;
 	}
 
 	public void update(Review updatedReview) {
-		description = updatedReview.getDescription();
+		content = updatedReview.getContent();
 		rating = updatedReview.getRating();
+	}
+
+	public void updateReply(Reply reply) {
+		this.reply = reply;
 	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/review/domain/ReviewRepository.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/domain/ReviewRepository.java
@@ -14,4 +14,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 	Slice<Review> findAllByExpertId(Long expertId, Pageable pageable);
 
 	Optional<Review> findById(Long id);
+
+	Slice<Review> findAllByExpertIdAndSubItemId(Long expertId, Long subItemId, Pageable pageable);
 }

--- a/src/main/java/com/foo/gosucatcher/domain/review/presentation/ReviewController.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/presentation/ReviewController.java
@@ -78,10 +78,10 @@ public class ReviewController {
 	}
 
 	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> delete(@PathVariable Long id) {
+	public ResponseEntity<Object> delete(@PathVariable Long id) {
 		reviewService.delete(id);
 
-		return ResponseEntity.ok(null);
+		return ResponseEntity.noContent().build();
 	}
 
 	@PostMapping("/{reviewId}/replies")

--- a/src/main/java/com/foo/gosucatcher/domain/review/presentation/ReviewController.java
+++ b/src/main/java/com/foo/gosucatcher/domain/review/presentation/ReviewController.java
@@ -16,8 +16,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.foo.gosucatcher.domain.review.application.ReviewService;
+import com.foo.gosucatcher.domain.review.application.dto.request.ReplyRequest;
 import com.foo.gosucatcher.domain.review.application.dto.request.ReviewCreateRequest;
 import com.foo.gosucatcher.domain.review.application.dto.request.ReviewUpdateRequest;
+import com.foo.gosucatcher.domain.review.application.dto.response.ReplyResponse;
 import com.foo.gosucatcher.domain.review.application.dto.response.ReviewResponse;
 import com.foo.gosucatcher.domain.review.application.dto.response.ReviewsResponse;
 
@@ -33,9 +35,9 @@ public class ReviewController {
 
 	@PostMapping("/{expertId}")
 	public ResponseEntity<ReviewResponse> create(
-			@PathVariable Long expertId,
-			@RequestParam Long subItemId,
-			@Validated @RequestBody ReviewCreateRequest reviewCreateRequest) {
+		@PathVariable Long expertId,
+		@RequestParam Long subItemId,
+		@Validated @RequestBody ReviewCreateRequest reviewCreateRequest) {
 		ReviewResponse reviewResponse = reviewService.create(expertId, subItemId, reviewCreateRequest);
 
 		return ResponseEntity.ok(reviewResponse);
@@ -43,8 +45,8 @@ public class ReviewController {
 
 	@GetMapping
 	public ResponseEntity<ReviewsResponse> findAll(
-			@PageableDefault(sort = "updatedAt", size = DEFAULT_PAGING_SIZE, direction = Sort.Direction.DESC)
-			Pageable pageable) {
+		@PageableDefault(sort = "updatedAt", size = DEFAULT_PAGING_SIZE, direction = Sort.Direction.DESC)
+		Pageable pageable) {
 		ReviewsResponse response = reviewService.findAll(pageable);
 
 		return ResponseEntity.ok(response);
@@ -52,10 +54,11 @@ public class ReviewController {
 
 	@GetMapping("/experts/{expertId}")
 	public ResponseEntity<ReviewsResponse> findAllByExpertId(@PathVariable Long expertId,
-			@PageableDefault(sort = "updatedAt", size = DEFAULT_PAGING_SIZE, direction = Sort.Direction.DESC)
-			Pageable pageable) {
+		@RequestParam(required = false) Long subItemId,
+		@PageableDefault(sort = "updatedAt", size = DEFAULT_PAGING_SIZE, direction = Sort.Direction.DESC)
+		Pageable pageable) {
 
-		ReviewsResponse response = reviewService.findAllByExpertId(pageable, expertId);
+		ReviewsResponse response = reviewService.findAllByExpertIdAndSubItem(pageable, expertId, subItemId);
 
 		return ResponseEntity.ok(response);
 	}
@@ -79,5 +82,39 @@ public class ReviewController {
 		reviewService.delete(id);
 
 		return ResponseEntity.ok(null);
+	}
+
+	@PostMapping("/{reviewId}/replies")
+	public ResponseEntity<ReplyResponse> createReply(
+		@PathVariable Long reviewId,
+		@Validated @RequestBody ReplyRequest replyRequest) {
+		ReplyResponse replyResponse = reviewService.createReply(reviewId, replyRequest);
+
+		return ResponseEntity.ok(replyResponse);
+	}
+
+	@PatchMapping("/{reviewId}/replies/{replyId}")
+	public ResponseEntity<Long> updateReply(
+		@PathVariable Long reviewId,
+		@PathVariable Long replyId,
+		@Validated @RequestBody ReplyRequest replyRequest) {
+
+		long updatedId = reviewService.updateReply(reviewId, replyId, replyRequest);
+
+		return ResponseEntity.ok(updatedId);
+	}
+
+	@GetMapping("/{reviewId}/replies/{replyId}")
+	public ResponseEntity<ReplyResponse> findReplyByID(@PathVariable Long reviewId, @PathVariable Long replyId) {
+		ReplyResponse replyResponse = reviewService.findReplyById(reviewId, replyId);
+
+		return ResponseEntity.ok(replyResponse);
+	}
+
+	@DeleteMapping("/{reviewId}/replies/{replyId}")
+	public ResponseEntity<Object> deleteReply(@PathVariable Long reviewId, @PathVariable Long replyId) {
+		reviewService.deleteReply(reviewId, replyId);
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/foo/gosucatcher/global/error/ErrorCode.java
+++ b/src/main/java/com/foo/gosucatcher/global/error/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 
 	//리뷰
 	NOT_FOUND_REVIEW("R001", "존재하지 않는 리뷰입니다"),
+	UNSUPPORTED_REPLIER("R002", "리뷰에 대한 답장은 서비스를 제공한 고수만 가능합니다."),
 
 	//회원
 	NOT_FOUND_MEMBER("M001", "존재하지 않는 회원입니다."),
@@ -50,7 +51,7 @@ public enum ErrorCode {
 
 	// 찜
 	NOT_FOUND_BUCKET("B001", "찜 내역이 존재하지 않습니다."),
-	NOT_SUPPORTED_SELF_BUCKET("B002", "자기 자신을 찜할 수 없습니다.");
+	UNSUPPORTED_SELF_BUCKET("B002", "자기 자신을 찜할 수 없습니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/foo/gosucatcher/global/error/ErrorCode.java
+++ b/src/main/java/com/foo/gosucatcher/global/error/ErrorCode.java
@@ -27,8 +27,9 @@ public enum ErrorCode {
 	INVALID_MAX_TRAVEL_DISTANCE("E003", "최대 이동거리는 0 이상이어야 합니다."),
 
 	//리뷰
-	NOT_FOUND_REVIEW("R001", "존재하지 않는 리뷰입니다"),
+	NOT_FOUND_REVIEW("R001", "존재하지 않는 리뷰입니다."),
 	UNSUPPORTED_REPLIER("R002", "리뷰에 대한 답장은 서비스를 제공한 고수만 가능합니다."),
+	NOT_FOUND_REPLY("R003", "존재하지 않는 리뷰에 대한 답장입니다."),
 
 	//회원
 	NOT_FOUND_MEMBER("M001", "존재하지 않는 회원입니다."),

--- a/src/main/java/com/foo/gosucatcher/global/error/exception/UnsupportedReplierException.java
+++ b/src/main/java/com/foo/gosucatcher/global/error/exception/UnsupportedReplierException.java
@@ -1,0 +1,10 @@
+package com.foo.gosucatcher.global.error.exception;
+
+import com.foo.gosucatcher.global.error.ErrorCode;
+
+public class UnsupportedReplierException extends BusinessException {
+
+	public UnsupportedReplierException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/test/java/com/foo/gosucatcher/domain/bucket/presentation/BucketControllerTest.java
+++ b/src/test/java/com/foo/gosucatcher/domain/bucket/presentation/BucketControllerTest.java
@@ -119,7 +119,7 @@ class BucketControllerTest {
 		// then
 		mockMvc.perform(MockMvcRequestBuilders.delete(apiBaseUrl + "/" + id)
 						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(MockMvcResultMatchers.status().isOk());
+				.andExpect(MockMvcResultMatchers.status().isNoContent());
 
 		doThrow(new EntityNotFoundException(ErrorCode.NOT_FOUND_BUCKET)).
 				when(bucketService)

--- a/src/test/java/com/foo/gosucatcher/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/com/foo/gosucatcher/domain/review/presentation/ReviewControllerTest.java
@@ -5,12 +5,14 @@ import static org.mockito.BDDMockito.doNothing;
 import static org.mockito.BDDMockito.doThrow;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
+import java.util.Hashtable;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -27,8 +29,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.foo.gosucatcher.domain.review.application.ReviewService;
+import com.foo.gosucatcher.domain.review.application.dto.request.ReplyRequest;
 import com.foo.gosucatcher.domain.review.application.dto.request.ReviewCreateRequest;
 import com.foo.gosucatcher.domain.review.application.dto.request.ReviewUpdateRequest;
+import com.foo.gosucatcher.domain.review.application.dto.response.ReplyResponse;
 import com.foo.gosucatcher.domain.review.application.dto.response.ReviewResponse;
 import com.foo.gosucatcher.domain.review.application.dto.response.ReviewsResponse;
 import com.foo.gosucatcher.global.error.ErrorCode;
@@ -55,7 +59,6 @@ class ReviewControllerTest {
 		@DisplayName("성공 - 리뷰를 추가할 수 있다")
 		@Test
 		void create() throws Exception {
-
 			// given
 			long expertId = 0L;
 			long subItemId = 0L;
@@ -63,69 +66,67 @@ class ReviewControllerTest {
 			LocalDateTime localDateTime = LocalDateTime.now();
 
 			ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(0L, "예시로 작성한 리뷰입니다", 5);
-			ReviewResponse reviewResponse = new ReviewResponse(0L, 0L, 0L, 0L, "예시로 작성한 리뷰입니다", 5, localDateTime,
-					localDateTime);
+			ReviewResponse reviewResponse = new ReviewResponse(0L, 0L, 0L, 0L, "예시로 작성한 리뷰입니다", 5, false,
+				new Hashtable<>(), localDateTime, localDateTime);
 			given(reviewService.create(any(Long.class), any(Long.class), any(ReviewCreateRequest.class)))
-					.willReturn(reviewResponse);
+				.willReturn(reviewResponse);
 
 			// when
 			// then
 			mockMvc.perform(MockMvcRequestBuilders.post(apiBaseUrl + "/" + expertId)
-							.contentType(MediaType.APPLICATION_JSON)
-							.param("subItemId", String.valueOf(subItemId))
-							.content(objectMapper.writeValueAsString(reviewCreateRequest)))
-					.andExpect(status().isOk())
-					.andExpect(jsonPath("$.id").value(0L))
-					.andExpect(jsonPath("$.expertId").value(expertId))
-					.andExpect(jsonPath("$.writerId").value(reviewCreateRequest.writerId()))
-					.andExpect(jsonPath("$.subItemId").value(subItemId))
-					.andExpect(jsonPath("$.description").value(reviewCreateRequest.description()))
-					.andExpect(jsonPath("$.rating").value(reviewCreateRequest.rating()));
+					.contentType(MediaType.APPLICATION_JSON)
+					.param("subItemId", String.valueOf(subItemId))
+					.content(objectMapper.writeValueAsString(reviewCreateRequest)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value(0L))
+				.andExpect(jsonPath("$.expertId").value(expertId))
+				.andExpect(jsonPath("$.writerId").value(reviewCreateRequest.writerId()))
+				.andExpect(jsonPath("$.subItemId").value(subItemId))
+				.andExpect(jsonPath("$.content").value(reviewCreateRequest.content()))
+				.andExpect(jsonPath("$.rating").value(reviewCreateRequest.rating()));
 		}
 
 		@DisplayName("실패 - 존재하지 않는 고수에 대해 리뷰를 등록할 수 없다")
 		@Test
 		void createFailed_NotFoundExpert() throws Exception {
-
 			// given
 			ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(0L, "예시로 작성한 리뷰입니다", 5);
 
 			doThrow(new EntityNotFoundException(ErrorCode.NOT_FOUND_EXPERT))
-					.when(reviewService).create(any(Long.class), any(Long.class), any(ReviewCreateRequest.class));
+				.when(reviewService).create(any(Long.class), any(Long.class), any(ReviewCreateRequest.class));
 
 			long subItemId = 0L;
 			// when
 			// then
 			mockMvc.perform(MockMvcRequestBuilders.post(apiBaseUrl + "/" + 0)
-							.contentType(MediaType.APPLICATION_JSON)
-							.param("subItemId", String.valueOf(subItemId))
-							.content(objectMapper.writeValueAsString(reviewCreateRequest)))
-					.andExpect(status().isNotFound())
-					.andExpect(jsonPath("$.code")
-							.value("E001"));
+					.contentType(MediaType.APPLICATION_JSON)
+					.param("subItemId", String.valueOf(subItemId))
+					.content(objectMapper.writeValueAsString(reviewCreateRequest)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code")
+					.value("E001"));
 		}
 
 		@DisplayName("실패 - 존재하지 않는 하위 서비스에 대해 리뷰를 등록할 수 없다")
 		@Test
 		void createFailed_NotFoundSubItem() throws Exception {
-
 			// given
 			ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(0L, "예시로 작성한 리뷰입니다", 5);
 			long expertId = 0L;
 			long subItemId = 0L;
 
 			doThrow(new EntityNotFoundException(ErrorCode.NOT_FOUND_SUB_ITEM))
-					.when(reviewService).create(any(Long.class), any(Long.class), any(ReviewCreateRequest.class));
+				.when(reviewService).create(any(Long.class), any(Long.class), any(ReviewCreateRequest.class));
 
 			// when
 			// then
 			mockMvc.perform(MockMvcRequestBuilders.post(apiBaseUrl + "/" + expertId)
-							.param("subItemId", String.valueOf(subItemId))
-							.contentType(MediaType.APPLICATION_JSON)
-							.content(objectMapper.writeValueAsString(reviewCreateRequest)))
-					.andExpect(status().isNotFound())
-					.andExpect(jsonPath("$.code")
-							.value("SI001"));
+					.contentType(MediaType.APPLICATION_JSON)
+					.param("subItemId", String.valueOf(subItemId))
+					.content(objectMapper.writeValueAsString(reviewCreateRequest)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code")
+					.value("SI001"));
 		}
 	}
 
@@ -135,8 +136,7 @@ class ReviewControllerTest {
 
 		@DisplayName("성공 - 특정 고수에 대한 리뷰를 모두 조회할 수 있다")
 		@Test
-		void findByExpertId() throws Exception {
-
+		void findAllByExpertId() throws Exception {
 			// given
 			ReviewCreateRequest firstReviewCreateRequest = new ReviewCreateRequest(1L, "예시로 작성한 첫번째 리뷰입니다", 5);
 			ReviewCreateRequest secondReviewCreateRequest = new ReviewCreateRequest(1L, "예시로 작성한 두번째 리뷰입니다", 3);
@@ -144,47 +144,50 @@ class ReviewControllerTest {
 			LocalDateTime localDateTime = LocalDateTime.now();
 
 			ReviewsResponse reviewsResponse = new ReviewsResponse(
-					List.of(new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, localDateTime, localDateTime),
-							new ReviewResponse(2L, 1L, 1L, 1L, "예시로 작성한 두번째 리뷰입니다", 3, localDateTime, localDateTime)),
-					true
+				List.of(
+					new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, false, new Hashtable<>(), localDateTime,
+						localDateTime),
+					new ReviewResponse(2L, 1L, 1L, 1L, "예시로 작성한 두번째 리뷰입니다", 3, false, new Hashtable<>(), localDateTime,
+						localDateTime)),
+				true
 			);
 
 			long subItemId = 1L;
 			long expertId = 1L;
 
-			given(reviewService.findAllByExpertId(any(PageRequest.class), any(Long.class)))
-					.willReturn(reviewsResponse);
+			given(reviewService.findAllByExpertIdAndSubItem(any(PageRequest.class), any(Long.class), any(Long.class)))
+				.willReturn(reviewsResponse);
 
 			// when
 			// then
 			mockMvc.perform(get(apiBaseUrl + "/experts/" + expertId)
-							.param("expertId", String.valueOf(expertId))
-							.contentType(MediaType.APPLICATION_JSON))
-					.andExpect(status().isOk())
-					.andExpect(jsonPath("$.ReviewsSliceResponse[0].id").value(1))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[0].expertId").value(expertId))
-					.andExpect(
-							jsonPath("$.ReviewsSliceResponse[0].writerId").value(firstReviewCreateRequest.writerId()))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[0].subItemId").value(subItemId))
-					.andExpect(
-							jsonPath("$.ReviewsSliceResponse[0].description").value(
-									firstReviewCreateRequest.description()))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[0].rating").value(firstReviewCreateRequest.rating()))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[1].id").value(2))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[1].expertId").value(expertId))
-					.andExpect(
-							jsonPath("$.ReviewsSliceResponse[1].writerId").value(secondReviewCreateRequest.writerId()))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[1].subItemId").value(subItemId))
-					.andExpect(
-							jsonPath("$.ReviewsSliceResponse[1].description").value(
-									secondReviewCreateRequest.description()))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[1].rating").value(secondReviewCreateRequest.rating()));
+					.param("subItemId", String.valueOf(subItemId))
+					.contentType(MediaType.APPLICATION_JSON))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.ReviewsSliceResponse[0].id").value(1L))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[0].expertId").value(expertId))
+				.andExpect(
+					jsonPath("$.ReviewsSliceResponse[0].writerId").value(firstReviewCreateRequest.writerId()))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[0].subItemId").value(subItemId))
+				.andExpect(
+					jsonPath("$.ReviewsSliceResponse[0].content").value(
+						firstReviewCreateRequest.content()))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[0].rating").value(firstReviewCreateRequest.rating()))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[1].id").value(2L))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[1].expertId").value(expertId))
+				.andExpect(
+					jsonPath("$.ReviewsSliceResponse[1].writerId").value(secondReviewCreateRequest.writerId()))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[1].subItemId").value(subItemId))
+				.andExpect(
+					jsonPath("$.ReviewsSliceResponse[1].content").value(
+						secondReviewCreateRequest.content()))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[1].rating").value(secondReviewCreateRequest.rating()));
 		}
 
 		@DisplayName("성공 - 리뷰를 모두 조회할 수 있다")
 		@Test
 		void findAll() throws Exception {
-
 			// given
 			ReviewCreateRequest firstReviewCreateRequest = new ReviewCreateRequest(1L, "예시로 작성한 첫번째 리뷰입니다", 5);
 			ReviewCreateRequest secondReviewCreateRequest = new ReviewCreateRequest(1L, "예시로 작성한 두번째 리뷰입니다", 3);
@@ -192,75 +195,78 @@ class ReviewControllerTest {
 			LocalDateTime localDateTime = LocalDateTime.now();
 
 			ReviewsResponse reviewsResponse = new ReviewsResponse(
-					List.of(new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, localDateTime, localDateTime),
-							new ReviewResponse(2L, 1L, 1L, 1L, "예시로 작성한 두번째 리뷰입니다", 3, localDateTime, localDateTime)),
-					true
+				List.of(
+					new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, false, new Hashtable<>(), localDateTime,
+						localDateTime),
+					new ReviewResponse(2L, 1L, 1L, 1L, "예시로 작성한 두번째 리뷰입니다", 3, false, new Hashtable<>(), localDateTime,
+						localDateTime)),
+				true
 			);
 
 			long expertId = 1L;
 			long subItemId = 1L;
 			given(reviewService.findAll(any(PageRequest.class)))
-					.willReturn(reviewsResponse);
+				.willReturn(reviewsResponse);
 
 			// when
 			// then
 			mockMvc.perform(get(apiBaseUrl)
-							.contentType(MediaType.APPLICATION_JSON))
-					.andExpect(status().isOk())
-					.andExpect(jsonPath("$.ReviewsSliceResponse[0].id").value(1))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[0].expertId").value(expertId))
-					.andExpect(
-							jsonPath("$.ReviewsSliceResponse[0].writerId").value(firstReviewCreateRequest.writerId()))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[0].subItemId").value(subItemId))
-					.andExpect(
-							jsonPath("$.ReviewsSliceResponse[0].description").value(
-									firstReviewCreateRequest.description()))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[0].rating").value(firstReviewCreateRequest.rating()))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[1].id").value(2))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[1].expertId").value(expertId))
-					.andExpect(
-							jsonPath("$.ReviewsSliceResponse[1].writerId").value(secondReviewCreateRequest.writerId()))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[1].subItemId").value(subItemId))
-					.andExpect(
-							jsonPath("$.ReviewsSliceResponse[1].description").value(
-									secondReviewCreateRequest.description()))
-					.andExpect(jsonPath("$.ReviewsSliceResponse[1].rating").value(secondReviewCreateRequest.rating()));
+					.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.ReviewsSliceResponse[0].id").value(1))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[0].expertId").value(expertId))
+				.andExpect(
+					jsonPath("$.ReviewsSliceResponse[0].writerId").value(firstReviewCreateRequest.writerId()))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[0].subItemId").value(subItemId))
+				.andExpect(
+					jsonPath("$.ReviewsSliceResponse[0].content").value(
+						firstReviewCreateRequest.content()))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[0].rating").value(firstReviewCreateRequest.rating()))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[1].id").value(2))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[1].expertId").value(expertId))
+				.andExpect(
+					jsonPath("$.ReviewsSliceResponse[1].writerId").value(secondReviewCreateRequest.writerId()))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[1].subItemId").value(subItemId))
+				.andExpect(
+					jsonPath("$.ReviewsSliceResponse[1].content").value(
+						secondReviewCreateRequest.content()))
+				.andExpect(jsonPath("$.ReviewsSliceResponse[1].rating").value(secondReviewCreateRequest.rating()));
 		}
 
 		@DisplayName("성공 - 리뷰를 아이디로 조회할 수 있다")
 		@Test
 		void findById() throws Exception {
-
 			// given
 			LocalDateTime localDateTime = LocalDateTime.now();
-			ReviewResponse reviewResponse = new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, localDateTime,
-					localDateTime);
+			ReviewResponse reviewResponse = new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, false,
+				new Hashtable<>(), localDateTime,
+				localDateTime);
 
 			long id = 1L;
 			given(reviewService.findById(any(Long.class)))
-					.willReturn(reviewResponse);
+				.willReturn(reviewResponse);
 
 			// when
 			// then
 			mockMvc.perform(get(apiBaseUrl + "/" + id)
-							.contentType(MediaType.APPLICATION_JSON))
-					.andExpect(status().isOk())
-					.andExpect(jsonPath("$.id").value(1))
-					.andExpect(jsonPath("$.expertId").value(reviewResponse.expertId()))
-					.andExpect(jsonPath("$.writerId").value(reviewResponse.writerId()))
-					.andExpect(jsonPath("$.subItemId").value(reviewResponse.subItemId()))
-					.andExpect(jsonPath("$.description").value(reviewResponse.description()))
-					.andExpect(jsonPath("$.rating").value(reviewResponse.rating()));
+					.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value(1))
+				.andExpect(jsonPath("$.expertId").value(reviewResponse.expertId()))
+				.andExpect(jsonPath("$.writerId").value(reviewResponse.writerId()))
+				.andExpect(jsonPath("$.subItemId").value(reviewResponse.subItemId()))
+				.andExpect(jsonPath("$.content").value(reviewResponse.content()))
+				.andExpect(jsonPath("$.rating").value(reviewResponse.rating()));
 		}
 	}
 
 	@Nested
 	@DisplayName("<리뷰 수정>")
 	class UpdateTest {
+
 		@DisplayName("성공 - 리뷰를 수정할 수 있다")
 		@Test
 		void update() throws Exception {
-
 			// given
 			long id = 0L;
 			ReviewUpdateRequest reviewUpdateRequest = new ReviewUpdateRequest("수정하고자 하는 리뷰입니다", 3);
@@ -268,33 +274,32 @@ class ReviewControllerTest {
 			// when
 			// then
 			when(reviewService.update(id, reviewUpdateRequest))
-					.thenReturn(id);
+				.thenReturn(id);
 
 			mockMvc.perform(patch(apiBaseUrl + "/" + id)
-							.contentType(MediaType.APPLICATION_JSON)
-							.content(objectMapper.writeValueAsString(reviewUpdateRequest)))
-					.andExpect(status().isOk())
-					.andExpect(jsonPath("$").value(id));
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(reviewUpdateRequest)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$").value(id));
 		}
 
 		@DisplayName("실패 - 존재하지 않는(삭제된) 리뷰를 수정 요청 하는 경우 에러가 발생한다")
 		@Test
 		void updateFailed_deleted() throws Exception {
-
 			// given
 			long id = 0L;
 			ReviewUpdateRequest reviewUpdateRequest = new ReviewUpdateRequest("수정하고자 하는 리뷰입니다", 3);
 			doThrow(new EntityNotFoundException(ErrorCode.NOT_FOUND_REVIEW)).
-					when(reviewService)
-					.update(any(Long.class), any(ReviewUpdateRequest.class));
+				when(reviewService)
+				.update(any(Long.class), any(ReviewUpdateRequest.class));
 
 			// when
 			// then
 			mockMvc.perform(patch(apiBaseUrl + "/" + id)
-							.contentType(MediaType.APPLICATION_JSON)
-							.content(objectMapper.writeValueAsString(reviewUpdateRequest)))
-					.andExpect(status().isNotFound())
-					.andExpect(jsonPath("$.code").value("R001"));
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(reviewUpdateRequest)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code").value("R001"));
 		}
 	}
 
@@ -305,18 +310,108 @@ class ReviewControllerTest {
 		@DisplayName("성공 - 리뷰를 삭제할 수 있다")
 		@Test
 		void delete() throws Exception {
-
 			// given
 			long id = 0L;
 			doNothing()
-					.when(reviewService)
-					.delete(id);
+				.when(reviewService)
+				.delete(id);
 
 			// when
 			// then
 			mockMvc.perform(MockMvcRequestBuilders.delete(apiBaseUrl + "/" + id)
-							.contentType(MediaType.APPLICATION_JSON))
-					.andExpect(MockMvcResultMatchers.status().isOk());
+					.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(MockMvcResultMatchers.status().isOk());
 		}
+	}
+
+	@Nested
+	@DisplayName("<리뷰에 대한 답글>")
+	class ReplyTest {
+
+		@DisplayName("성공 - 리뷰에 대한 답글을 추가할 수 있다")
+		@Test
+		void create() throws Exception {
+			// given
+			long reviewId = 0L;
+
+			LocalDateTime localDateTime = LocalDateTime.now();
+			ReplyRequest replyRequest = new ReplyRequest(0L, "리뷰에 대한 답글입니다");
+			ReplyResponse replyResponse = new ReplyResponse(0L, reviewId, "리뷰에 대한 답글입니다", localDateTime, localDateTime);
+
+			given(reviewService.createReply(any(Long.class), any(ReplyRequest.class)))
+				.willReturn(replyResponse);
+
+			// when
+			// then
+			mockMvc.perform(MockMvcRequestBuilders.post(apiBaseUrl + "/" + reviewId + "/replies")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(replyRequest)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value(0L))
+				.andExpect(jsonPath("$.reviewId").value(reviewId))
+				.andExpect(jsonPath("$.content").value(replyRequest.content()));
+		}
+
+		@DisplayName("성공 - 리뷰에 대한 답글을 수정할 수 있다")
+		@Test
+		void update() throws Exception {
+			// given
+			long reviewId = 0L;
+			long replyId = 0L;
+			LocalDateTime localDateTime = LocalDateTime.now();
+			ReplyRequest replyRequest = new ReplyRequest(0L, "리뷰에 대한 답글입니다");
+
+			given(reviewService.updateReply(any(Long.class), any(Long.class), any(ReplyRequest.class)))
+				.willReturn(replyId);
+
+			// when
+			// then
+			mockMvc.perform(MockMvcRequestBuilders.patch(apiBaseUrl + "/" + reviewId + "/replies/" + replyId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(replyRequest)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$").value(replyId));
+		}
+
+		@DisplayName("성공 - 리뷰에 대한 답글을 아이디로 조회할 수 있다")
+		@Test
+		void findById() throws Exception {
+			// given
+			long reviewId = 0L;
+			LocalDateTime localDateTime = LocalDateTime.now();
+			ReplyResponse replyResponse = new ReplyResponse(0L, reviewId, "리뷰에 대한 답글입니다", localDateTime, localDateTime);
+
+			long replyId = 1L;
+			given(reviewService.findReplyById(any(Long.class), any(Long.class)))
+				.willReturn(replyResponse);
+
+			// when
+			// then
+			mockMvc.perform(get(apiBaseUrl + "/" + reviewId + "/replies/" + replyId)
+					.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value(0L))
+				.andExpect(jsonPath("$.reviewId").value(reviewId))
+				.andExpect(jsonPath("$.content").value(replyResponse.content()));
+		}
+
+		@DisplayName("성공 - 리뷰에 대한 답글을 삭제할 수 있다")
+		@Test
+		void deleteReply() throws Exception {
+			// given
+			long reviewId = 1L;
+			long replyId = 4L;
+			doNothing()
+				.when(reviewService)
+				.deleteReply(reviewId, replyId);
+
+			// when
+			// then
+			mockMvc.perform(delete("/api/v1/reviews/1/replies/4")
+					.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(MockMvcResultMatchers.status().isNoContent());
+
+		}
+
 	}
 }

--- a/src/test/java/com/foo/gosucatcher/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/com/foo/gosucatcher/domain/review/presentation/ReviewControllerTest.java
@@ -401,13 +401,14 @@ class ReviewControllerTest {
 			// given
 			long reviewId = 1L;
 			long replyId = 4L;
+
 			doNothing()
 				.when(reviewService)
 				.deleteReply(reviewId, replyId);
 
 			// when
 			// then
-			mockMvc.perform(delete("/api/v1/reviews/1/replies/4")
+			mockMvc.perform(delete(apiBaseUrl + "/" + reviewId + "/replies/" + replyId)
 					.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(MockMvcResultMatchers.status().isNoContent());
 

--- a/src/test/java/com/foo/gosucatcher/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/com/foo/gosucatcher/domain/review/presentation/ReviewControllerTest.java
@@ -320,7 +320,7 @@ class ReviewControllerTest {
 			// then
 			mockMvc.perform(MockMvcRequestBuilders.delete(apiBaseUrl + "/" + id)
 					.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(MockMvcResultMatchers.status().isOk());
+				.andExpect(MockMvcResultMatchers.status().isNoContent());
 		}
 	}
 

--- a/src/test/java/com/foo/gosucatcher/domain/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/com/foo/gosucatcher/domain/review/presentation/ReviewControllerTest.java
@@ -12,7 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -67,7 +67,7 @@ class ReviewControllerTest {
 
 			ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(0L, "예시로 작성한 리뷰입니다", 5);
 			ReviewResponse reviewResponse = new ReviewResponse(0L, 0L, 0L, 0L, "예시로 작성한 리뷰입니다", 5, false,
-				new Hashtable<>(), localDateTime, localDateTime);
+				new HashMap<>(), localDateTime, localDateTime);
 			given(reviewService.create(any(Long.class), any(Long.class), any(ReviewCreateRequest.class)))
 				.willReturn(reviewResponse);
 
@@ -145,9 +145,9 @@ class ReviewControllerTest {
 
 			ReviewsResponse reviewsResponse = new ReviewsResponse(
 				List.of(
-					new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, false, new Hashtable<>(), localDateTime,
+					new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, false, new HashMap<>(), localDateTime,
 						localDateTime),
-					new ReviewResponse(2L, 1L, 1L, 1L, "예시로 작성한 두번째 리뷰입니다", 3, false, new Hashtable<>(), localDateTime,
+					new ReviewResponse(2L, 1L, 1L, 1L, "예시로 작성한 두번째 리뷰입니다", 3, false, new HashMap<>(), localDateTime,
 						localDateTime)),
 				true
 			);
@@ -196,9 +196,9 @@ class ReviewControllerTest {
 
 			ReviewsResponse reviewsResponse = new ReviewsResponse(
 				List.of(
-					new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, false, new Hashtable<>(), localDateTime,
+					new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, false, new HashMap<>(), localDateTime,
 						localDateTime),
-					new ReviewResponse(2L, 1L, 1L, 1L, "예시로 작성한 두번째 리뷰입니다", 3, false, new Hashtable<>(), localDateTime,
+					new ReviewResponse(2L, 1L, 1L, 1L, "예시로 작성한 두번째 리뷰입니다", 3, false, new HashMap<>(), localDateTime,
 						localDateTime)),
 				true
 			);
@@ -239,7 +239,7 @@ class ReviewControllerTest {
 			// given
 			LocalDateTime localDateTime = LocalDateTime.now();
 			ReviewResponse reviewResponse = new ReviewResponse(1L, 1L, 1L, 1L, "예시로 작성한 첫번째 리뷰입니다", 5, false,
-				new Hashtable<>(), localDateTime,
+				new HashMap<>(), localDateTime,
 				localDateTime);
 
 			long id = 1L;


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정/삭제

## 📌 변경 내용 요약
<!-- 한두줄로 간단히 요약해주세요. -->
- 리뷰에 대한 답글 기능 추가
- 리뷰 필드 중 리뷰 내용을 뜻하는 `description`의 네이밍 `content`로 변경

## 🔨 작업한 내용
<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->
- 리뷰 필드 중 리뷰 내용을 뜻하는 `description`의 네이밍 `content`로 변경
- 리뷰 조회시 제공하는 서비스 필터링 추가
<img width="728" alt="Screenshot 2023-09-07 at 10 34 51 PM" src="https://github.com/prgrms-be-devcourse/BE-04-GosuCatcher/assets/49016275/22822305-286d-4ee7-8d3e-0efe4f246081">
         
         
         
< 리뷰에 대한 답글 기능 > : 답글은 한개만 가능, 고수만 작성 가능

<img width="794" alt="Screenshot 2023-09-07 at 10 35 41 PM" src="https://github.com/prgrms-be-devcourse/BE-04-GosuCatcher/assets/49016275/3712772d-a73e-48c7-ae18-f643fd279a8e">


- 리뷰 조회시 리뷰에 대한 답글도 포함하도록 dto 수정
(ex)
```java
{
  "id": 1,
  "expertId": 1,
  "writerId": 3,
  "subItemId": 2,
  "content": "리뷰 예시 문장입니다",
  "rating": 5,
  "replyExisted": true,
  "reply": {
    "UpdatedAt": "2023-09-07T22:33:38.500878",
    "content": "리뷰에 대한 전문가의 답변 - ex) 리뷰 남겨 주셔서 감사합니다",
    "createdAt": "2023-09-07T22:33:38.500878",
    "id": "1"
  },
  "createdAt": "2023-09-07T22:33:19.858578",
  "updatedAt": "2023-09-07T22:33:38.503888"
}
```

-  리뷰에 대한 답글 API : 추가,수정,아이디로 조회,삭제 

## 💫 관련 링크

- [GS-56](https://gosu-catcher.atlassian.net/browse/GS-56) 
<!-- 대괄호 -> 지라 티켓 넘버 작성, 소괄호 -> 지라 티켓 링크를 넣어주세요. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/backend-devcourse/Git-Convention-4920f2238bfa460798866c7de3da89a2) 참고  (Win : `Ctrl + 클릭` / Mac : `cmd + 클릭` 하세요. ~~페이지 이탈 방지~~) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🙇🏽‍♂️ 기타 사항
리뷰에 대한 답글(Reply) 엔티티를 만들어서 리뷰에 필드로 넣고 `@OneToOne` 매핑을 해주었습니다.
```java
public class Review extends BaseEntity {

	@Id
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	private Long id;

	@OneToOne(fetch = FetchType.LAZY)
	@JoinColumn(name = "expert_id")
	private Expert expert;

	@OneToOne(fetch = FetchType.LAZY)
	@JoinColumn(name = "member_id")
	private Member member;

	@OneToOne(fetch = FetchType.LAZY)
	@JoinColumn(name = "sub_item_id")
	private SubItem subItem;

	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
	@JoinColumn(name = "reply_id")
	private Reply reply;

	private String content;

	private int rating;

	private boolean isDeleted = false;
```


`ReviewService` 내에 Reply에 대한 메소드들을 추가하고 별도의 `ReplyService`와 `ReplyController`는 만들지 않았는데 어떻게 생각하시는지 달아주시면 좋을 것 같습니다! 별도의 `ReplyService`를 만들지 않은 이유는 `ReplyService`를 `ReviewService`에서도 주입받아 사용해야하는데 순환참조의 위험이 있고 그렇다고 퍼사드 형태로 둘만한건 아닌 것 같아서입니다. 오히려 `ReviewService`에 포함하는게 맞지 않나 싶어서요...

[컨트롤러에 추가된 답장관련 API들]
<img width="916" alt="Screenshot 2023-09-07 at 10 50 12 PM" src="https://github.com/prgrms-be-devcourse/BE-04-GosuCatcher/assets/49016275/c060ae88-b09c-4634-876d-4e2615d7cd4d">


[GS-56]: https://gosu-catcher.atlassian.net/browse/GS-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ