### PR TITLE
[GS-73] 서비스 최근 검색어 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'commons-io:commons-io:2.8.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce:lettuce-core:6.1.5.RELEASE'
+
     //testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 tasks.named('test') {

--- a/src/main/java/com/foo/gosucatcher/config/RedisConfig.java
+++ b/src/main/java/com/foo/gosucatcher/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.foo.gosucatcher.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+	@Value("${spring.redis.host}")
+	private String host;
+
+	@Value("${spring.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/foo/gosucatcher/domain/item/application/dto/request/main/MainItemCreateRequest.java
+++ b/src/main/java/com/foo/gosucatcher/domain/item/application/dto/request/main/MainItemCreateRequest.java
@@ -1,24 +1,23 @@
 package com.foo.gosucatcher.domain.item.application.dto.request.main;
 
-import com.foo.gosucatcher.domain.item.domain.MainItem;
-
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
+import com.foo.gosucatcher.domain.item.domain.MainItem;
+
 public record MainItemCreateRequest(
-    @NotBlank(message = "서비스명은 필수 입력 입니다.")
-    @Pattern(regexp = "^[가-힣0-9\\s]+$", message = "서비스명은 한글과 숫자만 입력 가능합니다.")
-    String name,
-    @NotBlank(message = "해당 서비스의 부가 설명을 적어주세요.")
-    @Size(min = 6, message = "부가 설명은 6자 이상 작성해 주세요.")
-    String description
+	@NotBlank(message = "서비스명은 필수 입력 입니다.")
+	String name,
+
+	@NotBlank(message = "해당 서비스의 부가 설명을 적어주세요.")
+	@Size(min = 6, message = "부가 설명은 6자 이상 작성해 주세요.")
+	String description
 ) {
 
-    public static MainItem toMainItem(MainItemCreateRequest mainItemCreateRequest) {
-        return MainItem.builder()
-            .name(mainItemCreateRequest.name)
-            .description(mainItemCreateRequest.description)
-            .build();
-    }
+	public static MainItem toMainItem(MainItemCreateRequest mainItemCreateRequest) {
+		return MainItem.builder()
+			.name(mainItemCreateRequest.name)
+			.description(mainItemCreateRequest.description)
+			.build();
+	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/item/application/dto/request/main/MainItemUpdateRequest.java
+++ b/src/main/java/com/foo/gosucatcher/domain/item/application/dto/request/main/MainItemUpdateRequest.java
@@ -1,23 +1,22 @@
 package com.foo.gosucatcher.domain.item.application.dto.request.main;
 
-import com.foo.gosucatcher.domain.item.domain.MainItem;
-
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
+import com.foo.gosucatcher.domain.item.domain.MainItem;
+
 public record MainItemUpdateRequest(
-    @NotBlank(message = "서비스명은 필수 입력 입니다.")
-    @Pattern(regexp = "^[가-힣0-9\\s]+$", message = "서비스명은 한글과 숫자만 입력 가능합니다.")
-    String name,
-    @Size(min = 6, message = "부가 설명은 6자 이상 작성해 주세요.")
-    String description
+	@NotBlank(message = "서비스명은 필수 입력 입니다.")
+	String name,
+
+	@Size(min = 6, message = "부가 설명은 6자 이상 작성해 주세요.")
+	String description
 ) {
 
-    public static MainItem toMainItem(MainItemUpdateRequest mainItemUpdateRequest) {
-        return MainItem.builder()
-            .name(mainItemUpdateRequest.name)
-            .description(mainItemUpdateRequest.description)
-            .build();
-    }
+	public static MainItem toMainItem(MainItemUpdateRequest mainItemUpdateRequest) {
+		return MainItem.builder()
+			.name(mainItemUpdateRequest.name)
+			.description(mainItemUpdateRequest.description)
+			.build();
+	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/item/domain/MainItemRepository.java
+++ b/src/main/java/com/foo/gosucatcher/domain/item/domain/MainItemRepository.java
@@ -1,10 +1,10 @@
 package com.foo.gosucatcher.domain.item.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MainItemRepository extends JpaRepository<MainItem, Long> {
 
-    Optional<MainItem> findByName(String name);
+	Optional<MainItem> findByName(String name);
 }

--- a/src/main/java/com/foo/gosucatcher/domain/item/domain/SubItemRepository.java
+++ b/src/main/java/com/foo/gosucatcher/domain/item/domain/SubItemRepository.java
@@ -1,14 +1,20 @@
 package com.foo.gosucatcher.domain.item.domain;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SubItemRepository extends JpaRepository<SubItem, Long> {
 
-    Optional<SubItem> findByName(String name);
+	Optional<SubItem> findByName(String name);
 
-    Slice<SubItem> findAllByMainItemName(String name, Pageable pageable);
+	Slice<SubItem> findAllByMainItemName(String name, Pageable pageable);
+
+	@Query("SELECT si FROM SubItem si JOIN FETCH si.mainItem WHERE si.name LIKE %:keyword%")
+	List<SubItem> findByNameContains(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/foo/gosucatcher/domain/member/application/MemberService.java
+++ b/src/main/java/com/foo/gosucatcher/domain/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package com.foo.gosucatcher.domain.member.application;
 
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -40,6 +41,7 @@ public class MemberService {
 	private final MemberProfileRepository memberProfileRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final PasswordEncoder passwordEncoder;
+	private final RedisTemplate redisTemplate;
 
 	@Transactional(readOnly = true)
 	public MemberPasswordFoundResponse findPassword(String email) {
@@ -114,6 +116,9 @@ public class MemberService {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
 
+		String key = "search::" + member.getId();
+		redisTemplate.delete(key);
+
 		memberRepository.delete(member);
 	}
 
@@ -125,7 +130,7 @@ public class MemberService {
 	}
 
 	public MemberProfileChangeResponse changeMemberProfile(Long memberId,
-		@Validated MemberProfileChangeRequest memberProfileChangeRequest) {
+	                                                       @Validated MemberProfileChangeRequest memberProfileChangeRequest) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
 

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/SearchService.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/SearchService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class SearchService {
 
+	private static final int MAXIMUM_SAVED_VALUE = 5;
 	private final RedisTemplate<String, String> redisTemplate;
 	private final SubItemRepository subItemRepository;
 
@@ -40,7 +41,7 @@ public class SearchService {
 				}
 			}
 			if (!isKeywordInRedis) {
-				if (listOperations.size(key) == 5) {
+				if (listOperations.size(key) == MAXIMUM_SAVED_VALUE) {
 					listOperations.leftPop(key);
 				}
 				listOperations.rightPush(key, keyword);

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/SearchService.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/SearchService.java
@@ -51,7 +51,7 @@ public class SearchService {
 	}
 
 	@Transactional(readOnly = true)
-	public SearchListResponse getSearchList(Long memberId) {
+	public SearchListResponse getResentSearchList(Long memberId) {
 
 		String key = "search::" + memberId;
 

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/SearchService.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/SearchService.java
@@ -1,0 +1,66 @@
+package com.foo.gosucatcher.domain.search.application;
+
+import java.util.List;
+
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.foo.gosucatcher.domain.member.domain.Member;
+import com.foo.gosucatcher.domain.member.domain.MemberRepository;
+import com.foo.gosucatcher.domain.search.application.dto.response.SearchListResponse;
+import com.foo.gosucatcher.domain.search.application.dto.response.SearchResponse;
+import com.foo.gosucatcher.global.error.ErrorCode;
+import com.foo.gosucatcher.global.error.exception.EntityNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SearchService {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final MemberRepository memberRepository;
+
+	public SearchResponse searchKeyword(Long memberId, String keyword) {
+		if (keyword == null || keyword.isBlank() || keyword.isEmpty()) return null;
+
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+		String key = "search::" + member.getId();
+
+		ListOperations<String, String> listOperations = redisTemplate.opsForList();
+		for (String pastKeyword : listOperations.range(key, 0, listOperations.size(key))) {
+			if (String.valueOf(pastKeyword).equals(keyword)) return null;
+		}
+
+		if (listOperations.size(key) < 5) {
+			listOperations.rightPush(key, keyword);
+		} else if (listOperations.size(key) == 5) {
+			listOperations.leftPop(key);
+			listOperations.rightPush(key, keyword);
+		}
+
+		return SearchResponse.from(keyword);
+	}
+
+	@Transactional(readOnly = true)
+	public SearchListResponse getSearchList(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+		String key = "search::" + member.getId();
+
+		ListOperations<String, String> listOperations = redisTemplate.opsForList();
+
+
+		List<String> range = listOperations.range(key, 0, listOperations.size(key));
+
+		List<SearchResponse> searchResponses = range.stream()
+			.map(SearchResponse::from)
+			.toList();
+
+		return SearchListResponse.from(searchResponses);
+	}
+}

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchListResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchListResponse.java
@@ -6,7 +6,11 @@ public record SearchListResponse(
 	List<SearchResponse> searchResponseList
 ) {
 
-	public static SearchListResponse from(List<SearchResponse> searchResponses) {
+	public static SearchListResponse from(List<String> range) {
+		List<SearchResponse> searchResponses = range.stream()
+			.map(SearchResponse::from)
+			.toList();
+
 		return new SearchListResponse(searchResponses);
 	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchListResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchListResponse.java
@@ -1,0 +1,12 @@
+package com.foo.gosucatcher.domain.search.application.dto.response;
+
+import java.util.List;
+
+public record SearchListResponse(
+	List<SearchResponse> searchResponseList
+) {
+
+	public static SearchListResponse from(List<SearchResponse> searchResponses) {
+		return new SearchListResponse(searchResponses);
+	}
+}

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchResponse.java
@@ -1,10 +1,20 @@
 package com.foo.gosucatcher.domain.search.application.dto.response;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 public record SearchResponse(
-	String keyword
+	String keyword,
+	LocalDate searchTime
 ) {
 
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
 	public static SearchResponse from(String keyword) {
-		return new SearchResponse(keyword);
+		LocalDateTime currentTime = LocalDateTime.now();
+		String formattedTime = currentTime.format(formatter);
+
+		return new SearchResponse(keyword, LocalDate.parse(formattedTime, formatter));
 	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchResponse.java
@@ -1,0 +1,10 @@
+package com.foo.gosucatcher.domain.search.application.dto.response;
+
+public record SearchResponse(
+	String keyword
+) {
+
+	public static SearchResponse from(String keyword) {
+		return new SearchResponse(keyword);
+	}
+}

--- a/src/main/java/com/foo/gosucatcher/domain/search/presentation/SearchController.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/presentation/SearchController.java
@@ -7,9 +7,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.foo.gosucatcher.domain.item.application.dto.response.sub.SubItemsResponse;
 import com.foo.gosucatcher.domain.search.application.SearchService;
 import com.foo.gosucatcher.domain.search.application.dto.response.SearchListResponse;
-import com.foo.gosucatcher.domain.search.application.dto.response.SearchResponse;
 import com.foo.gosucatcher.global.aop.CurrentMemberId;
 
 import lombok.RequiredArgsConstructor;
@@ -23,10 +23,10 @@ public class SearchController {
 
 	@PostMapping
 	@CurrentMemberId
-	public ResponseEntity<SearchResponse> search(@RequestParam String keyword, Long memberId) {
-		SearchResponse searchResponse = searchService.searchKeyword(memberId, keyword);
+	public ResponseEntity<SubItemsResponse> search(@RequestParam String keyword, Long memberId) {
+		SubItemsResponse subItemsResponse = searchService.searchKeyword(memberId, keyword);
 
-		return ResponseEntity.ok(searchResponse);
+		return ResponseEntity.ok(subItemsResponse);
 	}
 
 	@GetMapping

--- a/src/main/java/com/foo/gosucatcher/domain/search/presentation/SearchController.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/presentation/SearchController.java
@@ -31,8 +31,8 @@ public class SearchController {
 
 	@GetMapping
 	@CurrentMemberId
-	public ResponseEntity<SearchListResponse> getSearchList(Long memberId) {
-		SearchListResponse searchList = searchService.getSearchList(memberId);
+	public ResponseEntity<SearchListResponse> getRecentSearchList(Long memberId) {
+		SearchListResponse searchList = searchService.getResentSearchList(memberId);
 
 		return ResponseEntity.ok(searchList);
 	}

--- a/src/main/java/com/foo/gosucatcher/domain/search/presentation/SearchController.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/presentation/SearchController.java
@@ -1,0 +1,39 @@
+package com.foo.gosucatcher.domain.search.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.foo.gosucatcher.domain.search.application.SearchService;
+import com.foo.gosucatcher.domain.search.application.dto.response.SearchListResponse;
+import com.foo.gosucatcher.domain.search.application.dto.response.SearchResponse;
+import com.foo.gosucatcher.global.aop.CurrentMemberId;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+	private final SearchService searchService;
+
+	@PostMapping
+	@CurrentMemberId
+	public ResponseEntity<SearchResponse> search(@RequestParam String keyword, Long memberId) {
+		SearchResponse searchResponse = searchService.searchKeyword(memberId, keyword);
+
+		return ResponseEntity.ok(searchResponse);
+	}
+
+	@GetMapping
+	@CurrentMemberId
+	public ResponseEntity<SearchListResponse> getSearchList(Long memberId) {
+		SearchListResponse searchList = searchService.getSearchList(memberId);
+
+		return ResponseEntity.ok(searchList);
+	}
+}

--- a/src/test/java/com/foo/gosucatcher/domain/search/presentation/SearchControllerTest.java
+++ b/src/test/java/com/foo/gosucatcher/domain/search/presentation/SearchControllerTest.java
@@ -1,0 +1,82 @@
+package com.foo.gosucatcher.domain.search.presentation;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.foo.gosucatcher.domain.item.application.dto.response.sub.SubItemResponse;
+import com.foo.gosucatcher.domain.item.application.dto.response.sub.SubItemsResponse;
+import com.foo.gosucatcher.domain.search.application.SearchService;
+import com.foo.gosucatcher.domain.search.application.dto.response.SearchListResponse;
+import com.foo.gosucatcher.domain.search.application.dto.response.SearchResponse;
+
+@WebMvcTest(value = {SearchController.class}, excludeAutoConfiguration = {SecurityAutoConfiguration.class})
+class SearchControllerTest {
+
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private SearchService searchService;
+
+	@DisplayName("키워드로 검색시 연관 서비스 조회 성공")
+	@Test
+	void searchKeywordTest() throws Exception {
+		//given
+		long memberId = 1L;
+		String keyword = "알바";
+
+		SubItemsResponse subItemsResponse = new SubItemsResponse(
+			List.of(new SubItemResponse(1L, "알바", "청소 알바", "청소 알바 설명")));
+
+		Mockito.when(searchService.searchKeyword(memberId, keyword)).thenReturn(subItemsResponse);
+
+		//when -> then
+		mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/search")
+				.param("keyword", keyword)
+				.param("memberId", String.valueOf(memberId))
+				.contentType(APPLICATION_JSON)
+				.accept(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.subItemsResponse[0].id").value(1L))
+			.andExpect(jsonPath("$.subItemsResponse[0].mainItemName").value("알바"))
+			.andDo(print());
+	}
+
+	@DisplayName("최근 검색 목록 반환 성공")
+	@Test
+	void getSearchListTest() throws Exception {
+		//given
+		long memberId = 1L;
+
+		SearchListResponse searchListResponse = new SearchListResponse(
+			List.of(new SearchResponse("영어", LocalDate.now()))
+		);
+
+		Mockito.when(searchService.getResentSearchList(memberId)).thenReturn(searchListResponse);
+
+		// Act and Assert
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/search")
+				.param("memberId", String.valueOf(memberId))
+				.contentType(APPLICATION_JSON)
+				.accept(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.searchResponseList[0].keyword").value("영어"))
+			.andDo(print());
+	}
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📌 변경 내용 요약
<!-- 한두줄로 간단히 요약해주세요. -->
- 레디스를 서비스 최근 검색어 구현 하였습니다. 
- 유저별 검색 목록 삭제는 회원 삭제시에 같이 삭제되게 하였습니다.

## 🔨 작업한 내용
<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->
- 로그인한 사용자의 정보를 가져와 각 유저들이 검색을 하면 그 키워드들이 최근 검색어 순으로 조회하는 기능을 구현하였습니다.
- 검색어는 5개까지가 되며, 그 이상 추가되면 가장 초기에 검색된 검색어가 사라지고 검색한 키워드가 저장됩니다.
- 해당 검색어에 포함하는 서비스가 없을 시 빈 객체가 반환되고, 최근 검색 목록에도 추가되지 않습니다.

### 검색어 입력시 포함된 서비스가 없을 시 (최근 검색어 목록에도 추가되지 않음)
<img width="980" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-GosuCatcher/assets/97447334/fe2a1732-a0e6-4b2a-919e-e8c0ac8b81c8">

### 검색어 입력시 포함된 서비스가 있을 때
<img width="1582" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-GosuCatcher/assets/97447334/0a196b68-5de2-4aaf-9a99-b7393b823567">

### 최근 검색어 반환 형식 (해당 이미지에는 누락되었지만, 검색 날짜도 포함 (시간 제외)
<img width="771" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-GosuCatcher/assets/97447334/0b6a56dc-204e-4612-9256-0bd89d1629db">


## 💫 관련 링크

- [GS-73](https://gosu-catcher.atlassian.net/browse/GS-73) 
<!-- 대괄호 -> 지라 티켓 넘버 작성, 소괄호 -> 지라 티켓 링크를 넣어주세요. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/backend-devcourse/Git-Convention-4920f2238bfa460798866c7de3da89a2) 참고  (Win : `Ctrl + 클릭` / Mac : `cmd + 클릭` 하세요. ~~페이지 이탈 방지~~) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🙇🏽‍♂️ 기타 사항
대부분 redis의 자료구조를 이용하여 코드를 보는데 어려움은 없으시리라 판단되지만, 혹여나 이해 안가는게 있으시면 리뷰 주세요!
+ 검색을 해서 키워드가 포함된 서비스들을 반환해주는데 이 값들을 이용해서 바로 견적 요청과 연결 시켜주면 될 듯합니다.

[GS-73]: https://gosu-catcher.atlassian.net/browse/GS-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ