### PR TITLE
[GS-74] 서비스 인기 검색어 목록 구현

### DIFF
--- a/src/main/java/com/foo/gosucatcher/config/RedisConfig.java
+++ b/src/main/java/com/foo/gosucatcher/config/RedisConfig.java
@@ -1,6 +1,6 @@
 package com.foo.gosucatcher.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -10,19 +10,21 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableRedisRepositories(redisTemplateRef = "searchRedisTemplate")
+@RequiredArgsConstructor
 public class RedisConfig {
 
-	@Value("${spring.redis.host}")
-	private String host;
-
-	@Value("${spring.redis.port}")
-	private int port;
+	private final RedisProperties redisProperties;
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
+		LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+		lettuceConnectionFactory.setDatabase(2);
+
+		return lettuceConnectionFactory;
 	}
 
 	@Bean

--- a/src/main/java/com/foo/gosucatcher/config/RedisConfig.java
+++ b/src/main/java/com/foo/gosucatcher/config/RedisConfig.java
@@ -11,7 +11,7 @@ import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableRedisRepositories
+@EnableRedisRepositories(redisTemplateRef = "searchRedisTemplate")
 public class RedisConfig {
 
 	@Value("${spring.redis.host}")
@@ -26,12 +26,12 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setConnectionFactory(redisConnectionFactory);
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+	public RedisTemplate<String, String> searchRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, String> searchRedisTemplate = new RedisTemplate<>();
+		searchRedisTemplate.setConnectionFactory(redisConnectionFactory);
+		searchRedisTemplate.setKeySerializer(new StringRedisSerializer());
+		searchRedisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
 
-		return redisTemplate;
+		return searchRedisTemplate;
 	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/SearchService.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/SearchService.java
@@ -1,9 +1,15 @@
 package com.foo.gosucatcher.domain.search.application;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +17,7 @@ import com.foo.gosucatcher.domain.item.application.dto.response.sub.SubItemsResp
 import com.foo.gosucatcher.domain.item.domain.SubItem;
 import com.foo.gosucatcher.domain.item.domain.SubItemRepository;
 import com.foo.gosucatcher.domain.search.application.dto.response.SearchListResponse;
+import com.foo.gosucatcher.domain.search.application.dto.response.SearchRankingListResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,32 +27,25 @@ import lombok.RequiredArgsConstructor;
 public class SearchService {
 
 	private static final int MAXIMUM_SAVED_VALUE = 5;
+	private static final String SEARCH_KEY = "search::";
+	private static final String SEARCH_COUNT_KEY = "search_count::";
+	private static final String POPULAR_KEYWORDS_KEY = "popular_keywords";
+
+	@Qualifier("searchRedisTemplate")
 	private final RedisTemplate<String, String> redisTemplate;
 	private final SubItemRepository subItemRepository;
 
 	public SubItemsResponse searchKeyword(Long memberId, String keyword) {
 		if (isInvalidKeyword(keyword)) return null;
 
-		String key = "search::" + memberId;
+		String key = SEARCH_KEY + memberId;
 
 		List<SubItem> subItems = subItemRepository.findByNameContains(keyword);
 
 		if (!subItems.isEmpty()) {
-			ListOperations<String, String> listOperations = redisTemplate.opsForList();
-			boolean isKeywordInRedis = false;
-
-			for (String pastKeyword : listOperations.range(key, 0, listOperations.size(key))) {
-				if (pastKeyword.equals(keyword)) {
-					isKeywordInRedis = true;
-					break;
-				}
-			}
-			if (!isKeywordInRedis) {
-				if (listOperations.size(key) == MAXIMUM_SAVED_VALUE) {
-					listOperations.leftPop(key);
-				}
-				listOperations.rightPush(key, keyword);
-			}
+			addKeywordInRedis(keyword, key);
+			incrementSearchCount(keyword);
+			updatePopularKeywordsList(keyword);
 		}
 
 		return SubItemsResponse.from(subItems);
@@ -54,16 +54,88 @@ public class SearchService {
 	@Transactional(readOnly = true)
 	public SearchListResponse getResentSearchList(Long memberId) {
 
-		String key = "search::" + memberId;
+		String key = SEARCH_KEY + memberId;
 
 		ListOperations<String, String> listOperations = redisTemplate.opsForList();
 
 		List<String> range = listOperations.range(key, 0, listOperations.size(key));
+		Collections.reverse(range);
 
 		return SearchListResponse.from(range);
 	}
 
+	@Transactional(readOnly = true)
+	public SearchRankingListResponse getPopularKeywords() {
+		Map<String, Long> keywordCounts = getKeywordCounts();
+
+		List<String> popularKeywords = getTopFivePopularKeywords(keywordCounts);
+
+		return SearchRankingListResponse.from(popularKeywords);
+	}
+
 	private boolean isInvalidKeyword(String keyword) {
 		return keyword == null || keyword.isBlank() || keyword.isEmpty();
+	}
+
+	private void addKeywordInRedis(String keyword, String key) {
+		ListOperations<String, String> listOperations = redisTemplate.opsForList();
+		boolean isKeywordInRedis = false;
+
+		for (String pastKeyword : listOperations.range(key, 0, listOperations.size(key))) {
+			if (pastKeyword.equals(keyword)) {
+				isKeywordInRedis = true;
+				break;
+			}
+		}
+		if (!isKeywordInRedis) {
+			if (listOperations.size(key) == MAXIMUM_SAVED_VALUE) {
+				listOperations.leftPop(key);
+			}
+			listOperations.rightPush(key, keyword);
+		}
+	}
+
+	private void incrementSearchCount(String keyword) {
+		String countKey = SEARCH_COUNT_KEY + keyword;
+
+		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+		valueOperations.increment(countKey);
+	}
+
+	private Map<String, Long> getKeywordCounts() {
+		Map<String, Long> keywordCounts = new HashMap<>();
+		Set<String> keys = redisTemplate.keys(SEARCH_COUNT_KEY + "*");
+
+		for (String key : keys) {
+			String keyword = key.replace(SEARCH_COUNT_KEY, "");
+			long count = Long.parseLong(redisTemplate.opsForValue().get(key));
+
+			keywordCounts.put(keyword, count);
+		}
+
+		return keywordCounts;
+	}
+
+	private List<String> getTopFivePopularKeywords(Map<String, Long> keywordCounts) {
+		List<String> popularKeywords = keywordCounts.entrySet()
+			.stream()
+			.sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+			.limit(MAXIMUM_SAVED_VALUE)
+			.map(Map.Entry::getKey)
+			.toList();
+
+		return popularKeywords;
+	}
+
+	private void updatePopularKeywordsList(String keyword) {
+		Long currentCount = redisTemplate.opsForList().size(POPULAR_KEYWORDS_KEY);
+
+		if (currentCount >= MAXIMUM_SAVED_VALUE) {
+			redisTemplate.opsForList().trim(POPULAR_KEYWORDS_KEY, 0, MAXIMUM_SAVED_VALUE - 1);
+		}
+
+		ListOperations<String, String> listOperations = redisTemplate.opsForList();
+		listOperations.rightPush(POPULAR_KEYWORDS_KEY, keyword);
 	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchRankingListResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchRankingListResponse.java
@@ -8,13 +8,14 @@ public record SearchRankingListResponse(
 ) {
 
 	public static SearchRankingListResponse from(List<String> searchRankingList) {
-		List<SearchRankingResponse> responses = new ArrayList<>();
+		List<SearchRankingResponse> rankingListResponse = new ArrayList<>();
 
 		int rating = 1;
 		for (String keyword : searchRankingList) {
-			responses.add(new SearchRankingResponse(rating, keyword));
+			SearchRankingResponse searchRankingResponse = SearchRankingResponse.of(rating, keyword);
+			rankingListResponse.add(searchRankingResponse);
 			rating++;
 		}
-		return new SearchRankingListResponse(responses);
+		return new SearchRankingListResponse(rankingListResponse);
 	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchRankingListResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchRankingListResponse.java
@@ -1,0 +1,20 @@
+package com.foo.gosucatcher.domain.search.application.dto.response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record SearchRankingListResponse(
+	List<SearchRankingResponse> searchRankingList
+) {
+
+	public static SearchRankingListResponse from(List<String> searchRankingList) {
+		List<SearchRankingResponse> responses = new ArrayList<>();
+
+		int rating = 1;
+		for (String keyword : searchRankingList) {
+			responses.add(new SearchRankingResponse(rating, keyword));
+			rating++;
+		}
+		return new SearchRankingListResponse(responses);
+	}
+}

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchRankingResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchRankingResponse.java
@@ -5,4 +5,7 @@ public record SearchRankingResponse(
 	String keyword
 ) {
 
+	public static SearchRankingResponse of(int rating, String keyword) {
+		return new SearchRankingResponse(rating, keyword);
+	}
 }

--- a/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchRankingResponse.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/application/dto/response/SearchRankingResponse.java
@@ -1,0 +1,8 @@
+package com.foo.gosucatcher.domain.search.application.dto.response;
+
+public record SearchRankingResponse(
+	int rating,
+	String keyword
+) {
+
+}

--- a/src/main/java/com/foo/gosucatcher/domain/search/presentation/SearchController.java
+++ b/src/main/java/com/foo/gosucatcher/domain/search/presentation/SearchController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.foo.gosucatcher.domain.item.application.dto.response.sub.SubItemsResponse;
 import com.foo.gosucatcher.domain.search.application.SearchService;
 import com.foo.gosucatcher.domain.search.application.dto.response.SearchListResponse;
+import com.foo.gosucatcher.domain.search.application.dto.response.SearchRankingListResponse;
 import com.foo.gosucatcher.global.aop.CurrentMemberId;
 
 import lombok.RequiredArgsConstructor;
@@ -35,5 +36,12 @@ public class SearchController {
 		SearchListResponse searchList = searchService.getResentSearchList(memberId);
 
 		return ResponseEntity.ok(searchList);
+	}
+
+	@GetMapping("/popularity")
+	public ResponseEntity<SearchRankingListResponse> getPopularSearchList() {
+		SearchRankingListResponse popularKeywords = searchService.getPopularKeywords();
+
+		return ResponseEntity.ok(popularKeywords);
 	}
 }

--- a/src/test/java/com/foo/gosucatcher/domain/search/presentation/SearchControllerTest.java
+++ b/src/test/java/com/foo/gosucatcher/domain/search/presentation/SearchControllerTest.java
@@ -1,6 +1,8 @@
 package com.foo.gosucatcher.domain.search.presentation;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -22,6 +24,8 @@ import com.foo.gosucatcher.domain.item.application.dto.response.sub.SubItemRespo
 import com.foo.gosucatcher.domain.item.application.dto.response.sub.SubItemsResponse;
 import com.foo.gosucatcher.domain.search.application.SearchService;
 import com.foo.gosucatcher.domain.search.application.dto.response.SearchListResponse;
+import com.foo.gosucatcher.domain.search.application.dto.response.SearchRankingListResponse;
+import com.foo.gosucatcher.domain.search.application.dto.response.SearchRankingResponse;
 import com.foo.gosucatcher.domain.search.application.dto.response.SearchResponse;
 
 @WebMvcTest(value = {SearchController.class}, excludeAutoConfiguration = {SecurityAutoConfiguration.class})
@@ -77,6 +81,34 @@ class SearchControllerTest {
 				.accept(APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.searchResponseList[0].keyword").value("영어"))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("인기 검색 목록 반환 성공")
+	void getPopularSearchListTest() throws Exception {
+
+		//given
+		List<SearchRankingResponse> popularKeywords = List.of(
+			SearchRankingResponse.of(1, "Java"),
+			SearchRankingResponse.of(2, "Spring"),
+			SearchRankingResponse.of(3, "REST"));
+
+		//when
+		SearchRankingListResponse searchRankingListResponse = new SearchRankingListResponse(popularKeywords);
+
+		when(searchService.getPopularKeywords()).thenReturn(searchRankingListResponse);
+
+		//then
+		mockMvc.perform(get("/api/v1/search/popularity")
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.searchRankingList[0].rating").value(1))
+			.andExpect(jsonPath("$.searchRankingList[0].keyword").value("Java"))
+			.andExpect(jsonPath("$.searchRankingList[1].rating").value(2))
+			.andExpect(jsonPath("$.searchRankingList[1].keyword").value("Spring"))
+			.andExpect(jsonPath("$.searchRankingList[2].rating").value(3))
+			.andExpect(jsonPath("$.searchRankingList[2].keyword").value("REST"))
 			.andDo(print());
 	}
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

## 📌 변경 내용 요약
<!-- 한두줄로 간단히 요약해주세요. -->
- 레디스를 이용하여 세부 서비스들의 인기 검색어 목록을 볼 수 있는 기능을 만들었습니다.

## 🔨 작업한 내용
<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요. 문장 형식으로 적더라도 하이픈으로 구분해주세요. -->
- 검색어를 입력시 해당 키워드에 카운팅 기능을 추가하였습니다.
  - `SEARCH_COUNT_KEY`와 검색 키워드(keyword)를 연결하여 검색 키워드에 대한 카운트를 저장할 Redis 키(Key)를 생성합니다. 이 키는 각 검색 키워드마다 별도로 생성되며, 검색 키워드가 `"example"`이라면 countKey는 `"search_count::example`"와 같이 생성됩니다. 
  - 그리고 해당 키워드가 검색될 시 그 값을 가져와 증가시켜 주었습니다.
- 카운팅을 가지고 인기 검색어를 정렬해서 볼 수 있는 기능을 추가했습니다.
  - 각 인기 검색어들로 분류하기 위해 위에서 `SEARCH_COUNT_KEY`로 저장했던 레디스의 key들을, 검색어만 남게 자른 후 (`"search_count::example"`  => `example`만 남음) Map에 key/value(검색 횟수) 형식으로 저장하였습니다.
  - 이후 정렬 및 갯수 제한을 걸어 사용자에게 볼 수 있도록 하였습니다.  
- 마찬가지로 존재하는 서비스가 없을시에는 인기 검색어 목록에도 추가되지 않습니다.
- 레디스에는 5개의 데이터만 저장되게 됩니다.
- 인기 검색어 호출은 로그인/비로그인 여부와 상관없이 모든 사용자가 조회할 수 있도록 하였습니다.

### 인기 검색어 반환 형태 (아래로 갈수록 검색 빈도가 적음. rating = 순위를 말함)
<img width="793" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-GosuCatcher/assets/97447334/a2dae43a-8b7c-448d-b661-cfbb08604654">


## 💫 관련 링크

- [GS-74](https://gosu-catcher.atlassian.net/browse/GS-74) 
<!-- 대괄호 -> 지라 티켓 넘버 작성, 소괄호 -> 지라 티켓 링크를 넣어주세요. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/backend-devcourse/Git-Convention-4920f2238bfa460798866c7de3da89a2) 참고  (Win : `Ctrl + 클릭` / Mac : `cmd + 클릭` 하세요. ~~페이지 이탈 방지~~) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🙇🏽‍♂️ 기타 사항
아직 테스트는 진행하지 않았습니다! 수정사항 반영 후 테스트 코드 함께 작성하여 올리겠습니다 ㅎㅎ

[GS-74]: https://gosu-catcher.atlassian.net/browse/GS-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ